### PR TITLE
Get parent at a single line

### DIFF
--- a/src/main/java/pdfwritebookmarks/LevelManager.java
+++ b/src/main/java/pdfwritebookmarks/LevelManager.java
@@ -51,18 +51,11 @@ public class LevelManager {
     public PDOutlineItem register(PDOutlineItem item, int level){
         // adds a new bookmark to the manager at level, and returns the
         // parent of the new bookmark
-        PDOutlineItem result = null;
         Object garbage = null; // used to pop to nirvana
         if (level == currentlevel){
             garbage = levelstack.pop(); // remove last bookmark from the same level
-            if (!(levelstack.empty())){
-                result = levelstack.peek();
-            } // result stays at null otherwise
         } else 
         if (level > currentlevel){
-            if (!(levelstack.empty())){
-                result = levelstack.peek();
-            } // result stays at null otherwise
             currentlevel++;
         } else
         if (level < currentlevel){
@@ -71,12 +64,10 @@ public class LevelManager {
                 currentlevel--;
             }
             currentlevel = level;
-            if (!(levelstack.empty())){
-                result = levelstack.peek();
-            } // result stays at null otherwise
         }
+        PDOutlineItem parent = levelstack.empty() ? null : levelstack.peek();
         levelstack.push(item);
-        return result;
+        return parent;
     }
     
 }


### PR DESCRIPTION
Makes it easier to understand the code. It is now clear that we always first remove the items until the parent is on top of the stack.